### PR TITLE
新規登録後の遷移先をルートパスに指定

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -10,9 +10,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # POST /resource
-  # def create
-  #   super
-  # end
+  def create
+    super
+  end
 
   # GET /resource/edit
   # def edit
@@ -50,10 +50,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
   # end
 
-  # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+  # 新規登録後の遷移ページ指定
+  def after_sign_up_path_for(resource)
+    root_path
+  end
 
   # The path used after sign up for inactive accounts.
   # def after_inactive_sign_up_path_for(resource)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   root to: 'posts#index'
-  devise_for :users
+  devise_for :users, controllers: {registrations: 'users/registrations'}
   resources :users
   resources :posts
 end


### PR DESCRIPTION
## What
　新規登録完了後、トップページ(root_path)に遷移させるもの
## Why
　新規登録完了と同時にアプリケーションを利用できるようにするため
　（deviseのデフォルト設定のままだと、ユーザー詳細ページに遷移するためトップページ行くまでに余計な手間がある。）