### PR TITLE
コメント欄・コメント表示欄のレイアウト調整

### DIFF
--- a/app/assets/stylesheets/posts/show.css
+++ b/app/assets/stylesheets/posts/show.css
@@ -63,3 +63,56 @@
   color: red;
   text-decoration: none;
 }
+
+.comment-container{
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 20px 0 0 0 ;
+}
+
+.comment-container h2{
+  font-size: 20px;
+  padding: 10px 0 10px 0;
+}
+
+.comment-index{
+  border: 1px solid black;
+  background-color: whitesmoke;
+  width: 500px;
+  height: 200px;
+  padding: 15px;
+}
+
+.comment-user{
+  padding: 0 0 10px 0;
+}
+
+.comment-user a{
+  text-decoration: none;
+}
+
+.comment-form{
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 10px;
+}
+
+.comment-text textarea{
+  width: 500px;
+}
+
+.comment-submit input{
+  width: 150px;
+  height: 50px;
+  float: right;
+}
+
+.notice{
+  padding: 10px 0 0 0;
+  font-size: 20px;
+  font-weight: bold;
+  color: coral
+}

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,8 +1,8 @@
 class Post < ApplicationRecord
   belongs_to :user
-  has_many :comments
+  has_many :comments, dependent: :destroy
   has_one_attached :image
-  has_many :likes
+  has_many :likes, dependent: :destroy
 
   with_options presence: true do
     validates :shop_name

--- a/app/views/posts/_like.html.erb
+++ b/app/views/posts/_like.html.erb
@@ -1,7 +1,9 @@
-<% if current_user.liked_by?(@post.id) %>
-  <i class="fas fa-heart", style="color: orangered;"><%= @post.likes.count %></i>
-  <%= link_to "いいね！済み", destroy_like_path(@post), method: :delete %>
-<% else %>
-  <i class="fas fa-heart", style="color: gray;"><%= @post.likes.count %></i>
-  <%= link_to "いいね！", create_like_path(@post), method: :post %>
+<% if user_signed_in? %>
+  <% if current_user.liked_by?(@post.id) %>
+    <i class="fas fa-heart", style="color: orangered;"><%= @post.likes.count %></i>
+    <%= link_to "いいね！済み", destroy_like_path(@post), method: :delete %>
+  <% else %>
+    <i class="fas fa-heart", style="color: gray;"><%= @post.likes.count %></i>
+    <%= link_to "いいね！", create_like_path(@post), method: :post %>
+  <% end %>
 <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -25,28 +25,37 @@
   </div>
 </div>
 
-<div class="comment-index">
-  <p>
-    <i class="fas fa-comment-dots"></i>
-    コメント一覧
-  </p>
-  <% if @comments %>
-    <% @comments.each do |comment|%>
-      <%= comment.text %>
-    <% end %>
+<div class="comment-container">
+  <% if user_signed_in? %>
+    <h2>
+      <i class="fas fa-comment-dots"></i>
+      コメント一覧
+    </h2>
+    <div class="comment-index">
+      <% if @comments %>
+        <% @comments.each do |comment|%>
+          <p><%= comment.text %></p>
+          <p class="comment-user"><%= link_to comment.user.name, user_path(comment.user.id) %>さん</p>
+        <% end %>
+      <% end %>
+    </div>
   <% end %>
 </div>
 
-<div class="comment-area">
+<div class="comment-form">
   <% if user_signed_in? %>
     <%= form_with(model: [@post, @comment], local: true) do |form| %>
-      <%= form.text_area :text, placeholder: "コメントを記入してください" %>
-      <%= form.submit "コメントする" %>
+      <div class="comment-text">
+        <%= form.text_area :text, placeholder: "コメントを記入してください" %>
+      </div>
+      <div class="comment-submit">
+        <%= form.submit "コメントする" %>
+      </div>
     <% end %>
   <% else %>
-    <p>
+    <p class="notice">
       <i class="fas fa-exclamation-circle"></i>
-      コメントの投稿には新規登録/ログインが必要です
-      </p>
+      コメントの閲覧および投稿には、新規登録/ログインが必要です
+    </p>
   <% end %>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -35,7 +35,7 @@
       <% if @comments %>
         <% @comments.each do |comment|%>
           <p><%= comment.text %></p>
-          <p class="comment-user"><%= link_to comment.user.name, user_path(comment.user.id) %>さん</p>
+          <p class="comment-user"><%= link_to comment.user.name, user_path(comment.user_id) %>さん</p>
         <% end %>
       <% end %>
     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,27 +3,27 @@
 <div class="user-container">
   <div class="user-profile">
     <div class="user-image">
-      <% if current_user.image.blank? %>
+      <% if @user.image.blank? %>
         <%= image_tag "/登録のピクトアイコン1.png" %>
       <% else %>
-        <%= image_tag current_user.image.variant(resize:'200x200') %>
+        <%= image_tag @user.image.variant(resize:'200x200') %>
       <% end %>
     </div>
     <div class="user-name">
-      <h2><%= current_user.name %><h2>
+      <h2><%= @user.name %><h2>
     </div>
     <div class="user-email">
-      <%= current_user.email %>
+      <%= @user.email %>
     </div>
     <div class="user-edit">
       <i class="far fa-edit"></i>
-      <%= link_to "ユーザー情報の編集", edit_user_path(current_user.id) %>
+      <%= link_to "ユーザー情報の編集", edit_user_path(@user.id) %>
     </div>
   </div>
 </div>
 
 <div class="user-post-container">
-  <h1><%= current_user.name %>さんの投稿一覧</h1>
+  <h1><%= @user.name %>さんの投稿一覧</h1>
   <% @posts.each do |post| %>
     <%= render partial: "posts/post", locals:{post: post} %>
   <% end %>


### PR DESCRIPTION
コメント欄のレイアウト調整
コメント閲覧および投稿はログインユーザーのみに制限
commentモデルとlikeモデルに対してdependent: :destroyオプションを付与
コメント一覧のユーザー名からユーザーページに遷移できるよう設定