### PR TITLE
userのupdateが成功しない不具合の修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,6 @@ class UsersController < ApplicationController
   end
 
   def update
-    binding.pry
     if current_user.update(user_params)
       redirect_to user_path(current_user)
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,6 @@ class User < ApplicationRecord
 
   validates :name, presence: true, format: {with: /[0-9a-zA-Z]/, message: "を正しく入力してください"}
   validates :email, presence: true
-  validates :password, length: {minimum: 6}
   
   def liked_by?(post_id)
     likes.where(post_id: post_id).exists?

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -14,7 +14,7 @@
     </div>
     <div class="password-field">
       <%= f.label "パスワード" %><br />
-      <%= f.password_field :password, placeholder:"6文字以上の半角英数字", autocomplete: "new-password" %>
+      <%= f.password_field :password, placeholder:"6文字以上の半角英数字", autocomplete: "new-password", minlength: "6" %>
     </div>
     <div class="password-confirm-field">
       <%= f.label "パスワード（確認）" %><br />

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe "ユーザー情報の編集", type: :system do
       # 「更新」ボタンをクリックする
       find('input[name = "commit"]').click
       # トップページに遷移することを確認する
-      expect(current_path).to eq root_path
+      expect(current_path).to eq user_path(@user.id)
     end
   end
 end


### PR DESCRIPTION
Userモデルのemailに対するバリデーション length:{minimum:6}が原因で動作しなかったので削除し、フォームバリデーションとして新規登録画面に記述し直して解決