### PR TITLE
画像投稿機能へのプレビュー機能追加実装

### DIFF
--- a/app/assets/stylesheets/users/show.css
+++ b/app/assets/stylesheets/users/show.css
@@ -17,7 +17,9 @@
 }
 
 .user-image img{
-  border-radius: 100px 100px;
+  width: 200px;
+  height: 200px;
+  border-radius: 50%;
 }
 
 .user-name h2{

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,6 +8,7 @@ require("@rails/ujs").start()
 require("@rails/activestorage").start()
 require("channels")
 require('./user_preview')
+require('./post_preview')
 
 
 // Uncomment to copy all static images under ../images to the output folder and reference

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,9 +4,10 @@
 // that code so it'll be compiled.
 
 require("@rails/ujs").start()
-require("turbolinks").start()
+// require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
+require('./user_preview')
 
 
 // Uncomment to copy all static images under ../images to the output folder and reference

--- a/app/javascript/packs/post_preview.js
+++ b/app/javascript/packs/post_preview.js
@@ -1,0 +1,33 @@
+if (document.URL.match( /edit/ ) || document.URL.match( /new/ ) ){
+  document.addEventListener('DOMContentLoaded', function(){
+    const ImageList = document.getElementById('image-list');
+
+    // 選択した画像を表示する関数
+    const createImageHTML = (blob) => {
+       // 画像を表示するためのdiv要素を生成
+      const imageElement = document.createElement('div');
+
+      // 表示する画像を生成
+      const blobImage = document.createElement('img');
+      blobImage.width = 250
+      blobImage.height = 250
+      blobImage.setAttribute('src', blob);
+      // 生成したHTMLの要素をブラウザに表示させる
+      imageElement.appendChild(blobImage);
+      ImageList.appendChild(imageElement);
+    };
+
+    document.getElementById('post_image').addEventListener('change', function(e){
+      // 画像が表示されている場合のみ、すでに存在している画像を削除する
+      const imageContent = document.querySelector('img');
+      if (imageContent){
+        imageContent.remove();
+      }
+
+      const file = e.target.files[0];
+      const blob = window.URL.createObjectURL(file);
+
+      createImageHTML(blob);
+    });
+  });
+}

--- a/app/javascript/packs/user_preview.js
+++ b/app/javascript/packs/user_preview.js
@@ -1,0 +1,33 @@
+if (document.URL.match( /edit/ ) ){
+  document.addEventListener('DOMContentLoaded', function(){
+    const ImageList = document.getElementById('image-list');
+
+    // 選択した画像を表示する関数
+    const createImageHTML = (blob) => {
+       // 画像を表示するためのdiv要素を生成
+      const imageElement = document.createElement('div');
+
+      // 表示する画像を生成
+      const blobImage = document.createElement('img');
+      blobImage.width = 200
+      blobImage.height = 200
+      blobImage.setAttribute('src', blob);
+      // 生成したHTMLの要素をブラウザに表示させる
+      imageElement.appendChild(blobImage);
+      ImageList.appendChild(imageElement);
+    };
+
+    document.getElementById('user_image').addEventListener('change', function(e){
+      // 画像が表示されている場合のみ、すでに存在している画像を削除する
+      const imageContent = document.querySelector('img');
+      if (imageContent){
+        imageContent.remove();
+      }
+
+      const file = e.target.files[0];
+      const blob = window.URL.createObjectURL(file);
+
+      createImageHTML(blob);
+    });
+  });
+}

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -12,6 +12,7 @@
       <%= form.text_field :shop_name, class: "shop_name" %>
       <p>写真</p>
       <%= form.file_field :image %>
+      <div id="image-list"></div>
       <p>タグ</p>
       <%= form.text_field :tag_list, value: @post.tag_list.join(',') %>
       <p>決済方式・お店に関する情報（必須）</p>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -11,6 +11,7 @@
       <%= form.text_field :shop_name, placeholder: "例: スターバックスコーヒー 原宿店", class: "shop_name" %>
       <p>写真</p>
       <%= form.file_field :image %>
+      <div id="image-list"></div>
       <p>タグ</p>
       <%= form.text_field :tag_list, value: @post.tag_list.join(','), placeholder: "例: 全クレジットカード対応" %>
       <p>決済方式・お店に関する情報（必須）</p>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -10,6 +10,7 @@
       <div class="edit-profile-image">
         <p>プロフィール画像</p>
         <%= form.file_field :image %>
+        <div id="image-list"></div>
       </div>
       <div class="edit-user-name">
         <p>ユーザー名</p>


### PR DESCRIPTION
## What
　ユーザー編集・新規投稿および投稿編集ページにおける画像プレビュー表示機能の実装
## Why
　アップロード時のサイズに合わせてプレビュー表示。これにより画像が可視化されるためユーザーがアップロード後の画像
　のイメージをつかみやすくなる