### PR TITLE
ユーザー編集ページ等　レイアウト調整

### DIFF
--- a/app/assets/stylesheets/posts/_comment.css
+++ b/app/assets/stylesheets/posts/_comment.css
@@ -1,0 +1,15 @@
+.comment{
+  padding: 0 40px 0 0 ;
+}
+
+.comment-user{
+  padding: 0 20px 0 0 ;
+}
+
+.comment-user a{
+  text-decoration: none;
+}
+
+.comment-bottom{
+  display: flex;
+}

--- a/app/assets/stylesheets/posts/_header.css
+++ b/app/assets/stylesheets/posts/_header.css
@@ -6,6 +6,7 @@
   height: 70px;
   width: 100%;
   position: fixed;
+  z-index: 10;
 }
 
 .app-name a{

--- a/app/assets/stylesheets/posts/show.css
+++ b/app/assets/stylesheets/posts/show.css
@@ -104,14 +104,8 @@
   width: 1000px;
   height: auto;
   padding: 15px;
-}
-
-.comment-user{
-  padding: 0 0 10px 0;
-}
-
-.comment-user a{
-  text-decoration: none;
+  display: flex;
+  flex-direction: column;
 }
 
 .comment-form{

--- a/app/assets/stylesheets/users/edit.css
+++ b/app/assets/stylesheets/users/edit.css
@@ -1,8 +1,13 @@
+.edit-head{
+  padding: 100px 0 0 0;
+  font-size: 30px;
+}
+
 .user-edit-container{
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 30px 0 0 0;
+  padding: 50px 0 0 0;
 }
 
 .user-edit-error{

--- a/app/views/posts/_comment.html.erb
+++ b/app/views/posts/_comment.html.erb
@@ -1,7 +1,15 @@
 <% @comments.each do |comment|%>
-  <p id="comment_<%= comment.id %>"><%= comment.text %></p>
-  <p class="comment-user" id="comment-user_<%= comment.id %>"><%= link_to comment.user.name, user_path(comment.user_id) %>さん</p>
-  <% if comment.user == current_user %>
-    <div id="comment-delete_<%= comment.id %>"><%= link_to "削除",  post_comment_path(comment.post_id, comment.id), method: :delete, remote: true %></div>
-  <% end %>
+  <div class="comment-top">
+    <p class="comment" id="comment_<%= comment.id %>"><%= comment.text %></p>
+  </div>
+  <div class="comment-bottom">
+    <p class="comment-user" id="comment-user_<%= comment.id %>"><%= link_to comment.user.name, user_path(comment.user_id) %>さん</p>
+    <% if comment.user == current_user %>
+      <div id="comment-delete_<%= comment.id %>">
+        <%= link_to post_comment_path(comment.post_id, comment.id), method: :delete, remote: true do %>
+          <i class="fas fa-trash" style="color: black;"></i>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
 <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: "posts/header" %>
 
-<h1>ユーザー情報の編集</h1>
+<h1 class="edit-head">ユーザー情報の編集</h1>
 <div class="user-edit-container">
   <%= form_with model: current_user, local: true do |form| %>
     <div class="user-edit-error">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -35,7 +35,5 @@
 
 <div class="user-post-container">
   <h2 class="user-post-index">投稿一覧</h2>
-  <% @posts.each do |post| %>
-    <%= render partial: "posts/post", locals:{post: post} %>
-  <% end %>
+  <%= render partial: "posts/post", locals:{posts: @posts} %>
 </div>


### PR DESCRIPTION
レイアウト調整
ヘッダーのZ座標（googlemapがスクロールするとヘッダーにかぶるので修正）
ユーザー編集ページのレイアウト調整
ユーザー詳細ページの投稿一覧に関する修正
ユーザー詳細ページ側と、呼び出す部分テンプレート側で２重にeachメソッドがかかっていたので、ユーザー詳細ページ側のeachメソッドを削除
コメント表示箇所のレイアウト調整