### PR TITLE
非ログイン時、タグをクリックすると初期ページに遷移する動作の改善

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,10 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  def after_sign_in_path_for(resource)
+    posts_path
+  end
+
   private
 
   def configure_permitted_parameters

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,0 +1,6 @@
+class HomesController < ApplicationController
+
+  def index
+  end
+
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -52,7 +52,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # 新規登録後の遷移ページ指定
   def after_sign_up_path_for(resource)
-    root_path
+    posts_path
   end
 
   # The path used after sign up for inactive accounts.

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -6,7 +6,7 @@ class Users::SessionsController < Devise::SessionsController
   def new_guest
     user = User.guest
     sign_in user
-    redirect_to root_path
+    redirect_to posts_path
   end
 
   # GET /resource/sign_in

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -1,0 +1,52 @@
+<%= render partial: "posts/header" %>
+
+  <% unless user_signed_in? %>
+    <div class="overview-area">
+      <h1>Payways</h1>
+      <p>キャッシュレス生活者に向けた店舗検索・情報共有サービス</p>
+      <div class="search-form-area">
+        <%= form_with url: search_posts_path, local: true, method: :get do |form| %>
+          <%= form.text_field :keyword, placeholder: "店名・キーワードを入力してください" %>
+          <%= form.submit "検索" %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+
+  <% unless user_signed_in? %>
+    <div class="about-service">
+      <h2>Paywaysのサービス</h2>
+      <h1>店舗検索と情報共有</h1>
+        <div class="icon-area">
+          <div class="credit-card-icon">
+            <p>〜 検索ツールとして 〜</p>
+            <%= image_tag  "/クレジットカードのアイコン素材.png" %>
+            <%= image_tag  "/スマホアイコン.png" %>
+            <p>クレジットカード/電子マネー/スマートフォン決済<br>キャッシュレス決済に対応しているお店をジャンル問わず、店名やキーワードで検索可能。</p>
+          </div>
+          <div class="icon-area">
+            <div class="comment-icon">
+              <p>〜 SNSとして 〜</p>
+              <%= image_tag  "/コメントのアイコン素材 その2.png" %>
+              <%= image_tag "/人物アイコン　チーム.png" %>
+              <p>ユーザー登録することで、あなたが行ったお店の情報を投稿し<br>ユーザー同士で共有することができます。</p>
+            </div>
+          </div>
+      </div>
+  <% end %>
+
+  <% unless user_signed_in? %>
+    <div class="invitation">
+      <h1>今すぐPaywaysをはじめてみましょう!</h1>
+      <div class="btn">
+        <div class="signup">
+          <%= link_to "新規登録", new_user_registration_path %>
+        </div>
+        <div class="signin">
+          <%= link_to "ログイン", new_user_session_path %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
+<%= render partial: "posts/footer" %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,66 +1,14 @@
 <%= render partial: "header" %>
 
-  <% unless user_signed_in? %>
-    <div class="overview-area">
-      <h1>Payways</h1>
-      <p>キャッシュレス生活者に向けた店舗検索・情報共有サービス</p>
-      <div class="search-form-area">
-        <%= form_with url: search_posts_path, local: true, method: :get do |form| %>
-          <%= form.text_field :keyword, placeholder: "店名・キーワードを入力してください" %>
-          <%= form.submit "検索" %>
-        <% end %>
-      </div>
-    </div>
+<div class="search-form-area">
+  <%= form_with url: search_posts_path, local: true, method: :get do |form| %>
+    <%= form.text_field :keyword, placeholder: "店名・キーワードを入力してください" %>
+    <%= form.submit "検索", class: "search" %>
   <% end %>
-
-  <% unless user_signed_in? %>
-    <div class="about-service">
-      <h2>Paywaysのサービス</h2>
-      <h1>店舗検索と情報共有</h1>
-        <div class="icon-area">
-          <div class="credit-card-icon">
-            <p>〜 検索ツールとして 〜</p>
-            <%= image_tag  "/クレジットカードのアイコン素材.png" %>
-            <%= image_tag  "/スマホアイコン.png" %>
-            <p>クレジットカード/電子マネー/スマートフォン決済<br>キャッシュレス決済に対応しているお店をジャンル問わず、店名やキーワードで検索可能。</p>
-          </div>
-          <div class="icon-area">
-            <div class="comment-icon">
-              <p>〜 SNSとして 〜</p>
-              <%= image_tag  "/コメントのアイコン素材 その2.png" %>
-              <%= image_tag "/人物アイコン　チーム.png" %>
-              <p>ユーザー登録することで、あなたが行ったお店の情報を投稿し<br>ユーザー同士で共有することができます。</p>
-            </div>
-          </div>
-      </div>
-  <% end %>
-
-  <% unless user_signed_in? %>
-    <div class="invitation">
-      <h1>今すぐPaywaysをはじめてみましょう!</h1>
-      <div class="btn">
-        <div class="signup">
-          <%= link_to "新規登録", new_user_registration_path %>
-        </div>
-        <div class="signin">
-          <%= link_to "ログイン", new_user_session_path %>
-        </div>
-      </div>
-    </div>
-  <% end %>
-
-
-  <% if user_signed_in? %>
-    <div class="search-form-area">
-      <%= form_with url: search_posts_path, local: true, method: :get do |form| %>
-        <%= form.text_field :keyword, placeholder: "店名・キーワードを入力してください" %>
-        <%= form.submit "検索", class: "search" %>
-      <% end %>
-    </div>
-    <div class="latest-post-area">
-      <h1>投稿一覧</h1>
-      <%= render partial: "post" %>
-    </div>
-  <% end %>
+</div>
+<div class="latest-post-area">
+  <h1>投稿一覧</h1>
+  <%= render partial: "post" %>
+</div>
 
 <%= render partial: "footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  root to: 'posts#index'
+  root to: 'homes#index'
 
   # タグにリンク付けし、同じタグを持つ投稿が一覧表示されるよう設定
   get 'tags/:tag', to: 'posts#index', as: :tag


### PR DESCRIPTION
初期ページのrootをhomes#indexに設定
新規登録・ログイン時（ゲスト含む）の遷移先をroot_pathからposts_pathに変更