### PR TITLE
Root path変更に伴う各ファイルのリダイレクト先修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -32,7 +32,7 @@ class PostsController < ApplicationController
 
   def update
     if @post.update(post_params)
-      redirect_to root_path
+      redirect_to posts_path
     else
       render :edit
     end
@@ -40,7 +40,7 @@ class PostsController < ApplicationController
 
   def destroy
     @post.destroy
-    redirect_to root_path
+    redirect_to posts_path
   end
 
 

--- a/app/views/posts/_header.html.erb
+++ b/app/views/posts/_header.html.erb
@@ -1,7 +1,11 @@
 <div class="main">
   <div class="header-area">
     <div class="app-name">
-      <%= link_to "Payways", root_path %>
+      <% if user_signed_in? %>
+        <%= link_to "Payways", posts_path %>
+      <% else %>
+        <%= link_to "Payways", root_path %>
+      <% end %>
     </div>
     <ul class="header-menu">
       <% if user_signed_in? %>

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "店舗情報の投稿", type: :system do
         find('input[name="commit"]').click  
       }.to change {Post.count}.by(1)
       # トップページに遷移する
-      visit root_path
+      visit posts_path
       # トップページに先程投稿した内容が表示されていることを確認する
       expect(page).to have_content(@posts_shop_name)
       expect(page).to have_content(@posts_explain)
@@ -71,7 +71,7 @@ RSpec.describe "投稿の編集", type: :system do
         find('input[name="commit"]').click
       }.to change { Post.count }.by(0)
       # （編集後）トップページに遷移する
-      visit root_path
+      visit posts_path
       # トップページには先程編集した投稿が存在する
       expect(page).to have_content("#{@post1.shop_name}+編集したテキスト")
       expect(page).to have_content("#{@post1.explain}+編集したテキスト")

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "ユーザー新規登録", type: :system do
         find('input[name = "commit"]').click  
       }.to change {User.count}.by(1)
       # トップページに遷移することを確認する
-      expect(current_path).to eq root_path
+      expect(current_path).to eq posts_path
     end
   end
   context 'ユーザー新規登録ができない時' do
@@ -68,7 +68,7 @@ RSpec.describe "ログイン", type: :system do
       # 「ログイン」ボタンをクリックする
       find('input[name = "commit"]').click
       # トップページへ遷移することを確認する
-      expect(current_path).to eq root_path
+      expect(current_path).to eq posts_path
       # 「新規登録」「ログイン」ボタンが表示されていないことを確認する
       expect(page).to have_no_content("新規登録")
       expect(page).to have_no_content("ログイン")
@@ -107,7 +107,7 @@ RSpec.describe "ユーザー情報の編集", type: :system do
       fill_in "user_email", with: @user.email
       fill_in "user_password", with: @user.password
       find('input[name = "commit"]').click
-      expect(current_path).to eq root_path
+      expect(current_path).to eq posts_path
       # ユーザーページへ遷移する
       visit user_path(@user.id)
       # 「ユーザー情報の編集」ボタンがあることを確認する


### PR DESCRIPTION
controllerのroot_pathリダイレクトをposts_pathに修
結合テストコードのログイン後・投稿後のroot_path部分をposts_pathに修正
ヘッダーロゴ部分のリンク先の修正
- ログイン時posts_pathに遷移
- 非ログイン時はroot_pathに遷移