### PR TITLE
Twitterログイン機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,3 +90,4 @@ gem 'kaminari'
 
 gem 'omniauth-rails_csrf_protection'
 gem 'omniauth-google-oauth2'
+gem 'omniauth-twitter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,6 +199,7 @@ GEM
     nio4r (2.5.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    oauth (0.5.4)
     oauth2 (1.4.4)
       faraday (>= 0.8, < 2.0)
       jwt (>= 1.0, < 3.0)
@@ -212,12 +213,18 @@ GEM
       jwt (>= 2.0)
       omniauth (>= 1.1.1)
       omniauth-oauth2 (>= 1.6)
+    omniauth-oauth (1.1.0)
+      oauth
+      omniauth (~> 1.0)
     omniauth-oauth2 (1.7.0)
       oauth2 (~> 1.4)
       omniauth (~> 1.9)
     omniauth-rails_csrf_protection (0.1.2)
       actionpack (>= 4.2)
       omniauth (>= 1.3.1)
+    omniauth-twitter (1.4.0)
+      omniauth-oauth (~> 1.1)
+      rack
     orm_adapter (0.5.0)
     parallel (1.19.2)
     parser (2.7.1.4)
@@ -403,6 +410,7 @@ DEPENDENCIES
   mysql2 (>= 0.4.4)
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
+  omniauth-twitter
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)

--- a/app/assets/stylesheets/homes/homes.css
+++ b/app/assets/stylesheets/homes/homes.css
@@ -127,6 +127,22 @@
   padding: 5px;
 }
 
+.twitter-signup-home{
+  padding: 10px 0 0 0;
+  display: flex;
+  justify-content: center;
+}
+
+.twitter-signup-home > .btn-info{
+  width: 440px;
+  height: 45px;
+}
+
+.twitter-signup-home i{
+  padding: 5px;
+  font-weight: bold;
+}
+
 /* タブレット */
 
 @media (max-width: 1024px) {

--- a/app/assets/stylesheets/signin.css
+++ b/app/assets/stylesheets/signin.css
@@ -42,3 +42,19 @@
 .google-signin i{
   padding: 5px;
 }
+
+.twitter-signin{
+  padding: 10px 0 0 0;
+  display: flex;
+  justify-content: center;
+}
+
+.twitter-signin > .btn-info{
+  width: 500px;
+  height: 45px;
+}
+
+.twitter-signin i{
+  padding: 5px;
+  font-weight: bold;
+}

--- a/app/assets/stylesheets/signup.css
+++ b/app/assets/stylesheets/signup.css
@@ -101,4 +101,21 @@
 
 .google-signup i{
   padding: 5px;
+  font-weight: bold;
+}
+
+.twitter-signup{
+  padding: 10px 0 0 0;
+  display: flex;
+  justify-content: center;
+}
+
+.twitter-signup > .btn-info{
+  width: 500px;
+  height: 45px;
+}
+
+.twitter-signup i{
+  padding: 5px;
+  font-weight: bold;
 }

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -6,6 +6,11 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     callback_for(:google)
   end
 
+  # callback for twitter
+  def twitter
+    callback_for(:twitter)
+  end
+
   def callback_for(provider)
     # user.rbのメソッド(from_omniauth)をここで使用
     # 'request.env["omniauth.auth"]'この中にgoogoleアカウントから取得したメールアドレスや、名前のデータが含まれている

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable,
-         :omniauthable, omniauth_providers: %i[google_oauth2]
+         :omniauthable, omniauth_providers: %i[google_oauth2 twitter]
   has_many :posts
   has_many :comments
   has_one_attached :image
@@ -27,10 +27,16 @@ class User < ApplicationRecord
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       user.name = auth.info.name
-      user.email = auth.info.email
+      user.email = User.dummy_email(auth)
       user.password = Devise.friendly_token[0,20]
       user.prefecture_id = 1
     end
+  end
+
+  private
+
+  def self.dummy_email(auth)
+    "#{auth.uid}-#{auth.provider}@example.com"
   end
 
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -36,7 +36,12 @@
   </div>
   <div class="google-signup">
     <%= link_to user_google_oauth2_omniauth_authorize_path, class: "btn btn-danger", method: :post do %>
-      <i class="fab fa-google"></i>Googleで登録
+      <i class="fab fa-google"> Googleで登録</i>
+    <% end %>
+  </div>
+  <div class="twitter-signup">
+    <%= link_to user_twitter_omniauth_authorize_path, class: "btn btn-info", method: :post do %>
+      <i class="fab fa-twitter"> Twitterで登録</i>
     <% end %>
   </div>
 <% end %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -44,4 +44,5 @@
       <i class="fab fa-twitter"> Twitterで登録</i>
     <% end %>
   </div>
+  
 <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -34,5 +34,10 @@
       <i class="fab fa-google"></i>Googleでログイン
     <% end %>
   </div>
+    <div class="twitter-signin">
+    <%= link_to user_twitter_omniauth_authorize_path, class: "btn btn-info", method: :post do %>
+      <i class="fab fa-twitter"> Twitterでログイン</i>
+    <% end %>
+  </div>
 
 <% end %>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -55,6 +55,11 @@
           <%= link_to user_google_oauth2_omniauth_authorize_path, class: "btn btn-danger", method: :post do %>
             <i class="fab fa-google"></i>Googleで登録
           <% end %>
+          <div class="twitter-signup-home">
+            <%= link_to user_twitter_omniauth_authorize_path, class: "btn btn-info", method: :post do %>
+              <i class="fab fa-twitter"> Twitterで登録</i>
+            <% end %>
+          </div>
         </div>
       </div>
     </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -273,6 +273,7 @@ Devise.setup do |config|
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
   config.omniauth :google_oauth2,ENV['GOOGLE_CLIENT_ID'],ENV['GOOGLE_CLIENT_SECRET']
+  config.omniauth :twitter,ENV['TWITTER_API_KEY'],ENV['TWITTER_API_SECRET']
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or


### PR DESCRIPTION
omniauth-twitterの導入

Userモデルのself.from_omniauthメソッド内でダミーのメールアドレスを生成するようコードを修正
- Twitter認証APIが仕様上メールアドレスを取得できないため。

各ページにボタンの配置とCSS調整