### PR TITLE
全体のレイアウト調整

### DIFF
--- a/app/assets/stylesheets/likes/index.css
+++ b/app/assets/stylesheets/likes/index.css
@@ -49,11 +49,11 @@
 }
 
 .liked-post-right-bottom p{
-  padding: 20px 0 0 0;
+  padding: 10px 0 0 0;
 }
 
 .liked-post-tags{
-  padding: 20px 0 20px 0 ;
+  padding: 15px 0 15px 0 ;
 }
 
 .liked-post-detail{

--- a/app/assets/stylesheets/posts/_header.css
+++ b/app/assets/stylesheets/posts/_header.css
@@ -10,7 +10,7 @@
 }
 
 .app-name a{
-  padding: 0 15px 0 15px;
+  padding: 0 15px 0 25px;
   font-size: 20px;
   font-family: 'Zapfino', sans-serif;
   text-decoration: none;
@@ -22,6 +22,7 @@
   align-items: center;
   justify-content: center;
   position: relative;
+  margin: 0 0 0 70px;
 }
 
 .header-search-input{
@@ -37,6 +38,7 @@
 
 .header-area ul{
   display: flex;
+  padding: 0 25px 0 0;
 }
 
 li a{

--- a/app/assets/stylesheets/posts/_post.css
+++ b/app/assets/stylesheets/posts/_post.css
@@ -29,6 +29,7 @@
 .post-right-top{
   border-bottom: 1px solid gainsboro;
   text-align: center;
+  margin: 0 0 10px 0;
 }
 
 .post-right-top a{
@@ -38,12 +39,8 @@
   font-weight: bold;
 }
 
-.post-right-bottom p{
-  padding: 20px 0 0 0;
-}
-
 .post-tags{
-  padding: 20px 0 20px 0 ;
+  padding: 15px 0 15px 0 ;
 }
 
 .post-detail{

--- a/app/assets/stylesheets/posts/index.css
+++ b/app/assets/stylesheets/posts/index.css
@@ -7,8 +7,3 @@
   height: auto;
 }
 
-.latest-post-area h1{
-  text-align: center;
-  padding: 15px 0 0 0;
-  font-size: 35px;
-}

--- a/app/assets/stylesheets/posts/new.css
+++ b/app/assets/stylesheets/posts/new.css
@@ -1,9 +1,3 @@
-h1{
-  padding: 100px 0 0 0;
-  text-align: center;
-  font-size: 40px;
-}
-
 .form-area{
   display: flex;
   flex-direction: column;

--- a/app/assets/stylesheets/posts/search.css
+++ b/app/assets/stylesheets/posts/search.css
@@ -1,6 +1,7 @@
 .search-head{
-  padding: 60px 0 10px 0;
   font-size: 30px;
+  text-align: center;
+  padding: 100px 0 10px 0;
 }
 
 .pagination {

--- a/app/assets/stylesheets/posts/show.css
+++ b/app/assets/stylesheets/posts/show.css
@@ -31,12 +31,9 @@
   font-size: 20px;
   font-weight: bold;
   color: black;
-  padding: 0 0 10px 0;
+  padding: 0 0 5px 0;
+  margin: 0 0 5px 0;
   border-bottom: 1px solid gainsboro;
-}
-
-.post-right-content p{
-  padding: 15px 0 0 0;
 }
 
 .like-btn{

--- a/app/assets/stylesheets/users/edit.css
+++ b/app/assets/stylesheets/users/edit.css
@@ -20,6 +20,9 @@
   padding: 0 0 20px 0;
 }
 
+#image-list img{
+  border-radius: 50%;
+}
 
 .edit-user-name{
   padding: 0 0 20px 0;

--- a/app/assets/stylesheets/users/show.css
+++ b/app/assets/stylesheets/users/show.css
@@ -3,12 +3,13 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding-top: 150px;
+  padding-top: 100px;
+  width: auto;
+  height: auto;
+  border-bottom: 1px solid gainsboro;
 }
 
 .user-profile{
-  width: 1000px;
-  height: auto;
   text-align: center;
 }
 
@@ -72,10 +73,4 @@
 #follower-count{
   padding: 10px 0 0 10px;
   font-size: 20px;
-}
-
-.user-post-index{
-  text-align: center;
-  font-size: 25px;
-  padding: 30px 0 0 0 ;
 }

--- a/app/javascript/packs/post_preview.js
+++ b/app/javascript/packs/post_preview.js
@@ -9,8 +9,8 @@ if (document.URL.match( /edit/ ) || document.URL.match( /new/ ) ){
 
       // 表示する画像を生成
       const blobImage = document.createElement('img');
-      blobImage.width = 250
-      blobImage.height = 250
+      blobImage.width = 300
+      blobImage.height = 300
       blobImage.setAttribute('src', blob);
       // 生成したHTMLの要素をブラウザに表示させる
       imageElement.appendChild(blobImage);

--- a/app/javascript/packs/user_preview.js
+++ b/app/javascript/packs/user_preview.js
@@ -9,8 +9,8 @@ if (document.URL.match( /edit/ ) ){
 
       // 表示する画像を生成
       const blobImage = document.createElement('img');
-      blobImage.width = 200
-      blobImage.height = 200
+      blobImage.width = 150
+      blobImage.height = 150
       blobImage.setAttribute('src', blob);
       // 生成したHTMLの要素をブラウザに表示させる
       imageElement.appendChild(blobImage);

--- a/app/views/likes/index.html.erb
+++ b/app/views/likes/index.html.erb
@@ -23,6 +23,9 @@
             <%= link_to l_post.tag_list, tag_path(l_post.tag_list), class:"fas fa-hashtag" %>
           <% end %>
         </div>
+        <div class="posted-user">
+          <p>Posted by:<%= link_to l_post.user.name, user_path(l_post.user_id) %></p>
+        </div>
         <div class="liked-post-detail">
           <%= link_to "詳細", post_path(l_post.id), class:"btn btn-liked-post-detail"%>
         </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -21,6 +21,9 @@
                     <% end %>
                 <% end %>
             </div>
+            <div class="posted-user">
+                <p>Posted by:<%= link_to post.user.name, user_path(post.user_id) %></p>
+            </div>
             <div class="post-detail">
                 <%= link_to "詳細", post_path(post.id), class:"btn btn-post-detail"%>
             </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -7,7 +7,6 @@
   <% end %>
 </div>
 <div class="latest-post-area">
-  <h1>投稿一覧</h1>
   <%= render partial: "post" %>
 </div>
 

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,21 +1,20 @@
 <%= render partial: "header" %>
 
-<h1>新規投稿</h1>
 <div class="form-area">
   <%= form_with(model: @post, local: true) do |form|%>
     <div class="posting-error">
       <%= render "shared/error_messages", model: form.object %>
     </div>
     <div class="post-form">
-      <p>店名（必須）</p>
-      <%= form.text_field :shop_name, placeholder: "例: スターバックスコーヒー 原宿店", class: "shop_name" %>
       <p>写真</p>
       <%= form.file_field :image %>
       <div id="image-list"></div>
-      <p>タグ</p>
-      <%= form.text_field :tag_list, value: @post.tag_list.join(','), placeholder: "例: 全クレジットカード対応" %>
+      <p>店名（必須）</p>
+      <%= form.text_field :shop_name, placeholder: "例: スターバックスコーヒー 原宿店", class: "shop_name" %>
       <p>決済方式・お店に関する情報（必須）</p>
       <%= form.text_area :explain, placeholder: "例: クレジットカードは全ブランド使えます。カフェラテとサンドイッチがとても美味しいお店です。 ", class: "shop_explain" %>
+      <p>タグ</p>
+      <%= form.text_field :tag_list, value: @post.tag_list.join(','), placeholder: "例: 全クレジットカード対応" %>
     </div>
     <div class="post-btn">
       <%= form.submit "投稿する"%>

--- a/app/views/posts/search.html.erb
+++ b/app/views/posts/search.html.erb
@@ -1,15 +1,8 @@
 <%= render partial: "header" %>
 
-  <div class="search-form-area">
-    <%= form_with url: search_posts_path, local: true, method: :get do |form| %>
-      <%= form.text_field :keyword, placeholder: "店名・キーワードを入力してください" %>
-      <%= form.submit "検索" %>
-    <% end %>
-  </div>
-
-  <div class="search-post-area">
-    <h1 class="search-head">検索結果</h1>
-    <%= render partial: "post", locals: { posts: @posts } %>
-  </div>
+<div class="search-post-area">
+  <h2 class="search-head">検索結果：<%= params[:keyword] %></h2>
+  <%= render partial: "post", locals: { posts: @posts } %>
+</div>
 
 <%= paginate @posts %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -18,6 +18,9 @@
         <% end %>
       <% end %>
     </div>
+    <div class="posted-user">
+      <p>Posted by:<%= link_to @post.user.name, user_path(@post.user_id) %></p>
+    </div>
     <div class="like-btn">
       <div class="buttons_<%= @post.id %>" id="buttons"><%= render partial: "like", post: @post %></div>
     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -44,6 +44,5 @@
 </div>
 
 <div class="user-post-container">
-  <h2 class="user-post-index">投稿一覧</h2>
   <%= render partial: "posts/post", locals:{posts: @posts} %>
 </div>


### PR DESCRIPTION
## 内容
ヘッダーの各要素のpadding・margin調整
新規投稿画面のフォームの配置順並び替え、プレビュー表示の画像サイズ変更
ユーザー編集ページの画像プレビュー表示をユーザー詳細ページの画像表示と同じになるよう設定
ユーザー詳細ページのレイアウト調整
検索結果ページの「検索結果」部分の表記を、入力したキーワードが分かるよう記述を変更
投稿一覧ページのレイアウト調整
投稿表示部分に投稿者名の表示、各ページ投稿表示部分のpadding,margin調整