### PR TITLE
[fix]URI.escape → Addressable::URI.encodeに修正

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -50,7 +50,8 @@ class Post < ApplicationRecord
   # postsテーブルのshop_nameを元に、GoogleMaps API（geocoder）で緯度経度を計算する処理
   def geocode
     require 'net/http'
-    uri = URI.escape('https://maps.googleapis.com/maps/api/geocode/json?address=' + shop_name + '&key=' + ENV['MAPS_API_KEY'])
+    require 'addressable/template'
+    uri = Addressable::URI.encode('https://maps.googleapis.com/maps/api/geocode/json?address=' + shop_name + '&key=' + ENV['MAPS_API_KEY'])
     res = Net::HTTP.get_response(URI.parse(uri))
     response = JSON.parse(res.body)
     if response['status'] == 'OK'


### PR DESCRIPTION
Rubocop実行の際、URI.escapeが非推奨（obslute）だったため。